### PR TITLE
Cryptic Crystal | Point release | v17 | DNM yet...

### DIFF
--- a/src/cryptonote_basic/cryptonote_basic_impl.cpp
+++ b/src/cryptonote_basic/cryptonote_basic_impl.cpp
@@ -58,6 +58,7 @@ using namespace epee;
 #define MAINNET_HARDFORK_V14_HEIGHT ((uint64_t)(337816)) // MAINNET v14 hard fork
 #define MAINNET_HARDFORK_V15_HEIGHT ((uint64_t)(337838)) // MAINNET v15 hard fork 
 #define MAINNET_HARDFORK_CRYSTALEUM_HEIGHT ((uint64_t)(500060)) // MAINNET crystaleum hard fork
+#define MAINNET_HARDFORK_V17_HEIGHT ((uint64_t)(1012915)) // MAINNET v17 hard fork 
 
 #define TESTNET_ELECTRONERO_HARDFORK ((uint64_t)(12746)) // Electronero TESTNET fork height
 #define TESTNET_HARDFORK_V1_HEIGHT ((uint64_t)(1)) // TESTNET v1 

--- a/src/cryptonote_basic/cryptonote_basic_impl.cpp
+++ b/src/cryptonote_basic/cryptonote_basic_impl.cpp
@@ -163,11 +163,11 @@ namespace cryptonote {
     // rounding (floor) base reward
     if (version > 7)
     {
-    base_reward = base_reward / round_factor * round_factor;
+      base_reward = base_reward / round_factor * round_factor;
     }
     if (version < 2) 
     {
-     base_reward = (MONEY_SUPPLY_ETN - already_generated_coins) >> emission_speed;
+      base_reward = (MONEY_SUPPLY_ETN - already_generated_coins) >> emission_speed;
     }
    // maybe throw chain into final subsidy after genesis? todo
    // maybe work on better final subsidy later - todo, once emissions is final 
@@ -175,6 +175,10 @@ namespace cryptonote {
     if (base_reward < FINAL_SUBSIDY_ACTIVATOR){
      if (already_generated_coins >= TOKEN_SUPPLY){
        base_reward = FINAL_SUBSIDY_PER_MINUTE;
+     }
+     if (version >= 17)
+     {
+       base_reward = FINAL_SUBSIDY_PER_BLOCK;
      }
     }
     

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -63,7 +63,7 @@
 #define COIN                                            ((uint64_t)1000000000000) // 1 * pow(10, 12)
 #define EMISSION_SPEED_FACTOR_PER_MINUTE                (20)
 #define FINAL_SUBSIDY_PER_MINUTE                        ((uint64_t)1200000) // 0.000001200000 CRFI
-#define FINAL_SUBSIDY_PER_BLOCK                         ((uint64_t)592468)  // 0.000000592468 CRFI
+#define FINAL_SUBSIDY_PER_BLOCK                         ((uint64_t)1392468) // 0.000001392468 CRFI
 
 #define CRYPTONOTE_REWARD_BLOCKS_WINDOW                 100
 #define CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE       240 * 1024    // 240kB, used for emissions
@@ -77,8 +77,8 @@
 
 #define FEE_PER_KB_OLD                                  ((uint64_t)120000) // .1 * pow(10, 1)
 #define FEE_PER_KB_V2                                   ((uint64_t)120000) // .4 * pow(10, 1)
-#define FEE_PER_KB                                      ((uint64_t)120000) // 0.000000120000 
-#define FEE_PER_KB_V3                                   ((uint64_t)1000000) //0.000001000000
+#define FEE_PER_KB                                      ((uint64_t)120000) //    0.000000120000 
+#define FEE_PER_KB_V3                                   ((uint64_t)100000000) // 0.000010000
 #define DYNAMIC_FEE_PER_KB_BASE_FEE                     ((uint64_t)2500000000) // .25 * pow(10, 8)
 #define DYNAMIC_FEE_PER_KB_BASE_BLOCK_REWARD            ((uint64_t)2500000000) // .25 * pow(10, 8)
 #define DYNAMIC_FEE_PER_KB_BASE_FEE_V5                  ((uint64_t)20000000 * (uint64_t)CRYPTONOTE_TX_FEE_RESERVED_SIZE / CRYPTONOTE_BLOCK_FEE_REWARD_ZONE_V5)
@@ -169,7 +169,7 @@ namespace config
 {
   uint64_t const DEFAULT_FEE_ATOMIC_XMR_PER_KB = 500;
   uint8_t const FEE_CALCULATION_MAX_RETRIES = 10;
-  uint64_t const DEFAULT_DUST_THRESHOLD = ((uint64_t)1000000); // 2 * pow(10, 7)
+  uint64_t const DEFAULT_DUST_THRESHOLD = ((uint64_t)100000000); // 2 * pow(10, 8)
   uint64_t const BASE_REWARD_CLAMP_THRESHOLD = ((uint64_t)100000000); // pow(10, 8)
   std::string const P2P_REMOTE_DEBUG_TRUSTED_PUB_KEY = "0000000000000000000000000000000000000000000000000000000000000000";
   uint64_t const CRYPTONOTE_PUBLIC_ADDRESS_BASE58_PREFIX = 343; //cx

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -167,7 +167,7 @@
 // New constants are intended to go here
 namespace config
 {
-  uint64_t const DEFAULT_FEE_ATOMIC_XMR_PER_KB = 5;
+  uint64_t const DEFAULT_FEE_ATOMIC_XMR_PER_KB = 500;
   uint8_t const FEE_CALCULATION_MAX_RETRIES = 10;
   uint64_t const DEFAULT_DUST_THRESHOLD = ((uint64_t)20000000); // 2 * pow(10, 7)
   uint64_t const BASE_REWARD_CLAMP_THRESHOLD = ((uint64_t)100000000); // pow(10, 8)

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -1,4 +1,6 @@
-// Copyright (c) 2014-2018, The Monero Project
+// Copyright (c) 2014-2018, The Monero Project 
+// Portions Copyright (c) 2018-2021, Electronero Network 
+// Portions Copyright (c) 2020-2021, Crystaleum Core 
 //
 // All rights reserved.
 //
@@ -34,23 +36,23 @@
 #include <boost/uuid/uuid.hpp>
 
 #define CRYPTONOTE_DNS_TIMEOUT_MS                       20000
-
 #define CRYPTONOTE_MAX_BLOCK_NUMBER                     500000000
 #define CRYPTONOTE_MAX_BLOCK_SIZE                       500000000  // block header blob limit, never used!
 #define CRYPTONOTE_GETBLOCKTEMPLATE_MAX_BLOCK_SIZE      196608 //size of block (bytes) that is the maximum that miners will produce
 #define CRYPTONOTE_MAX_TX_SIZE                          1000000000
 #define CRYPTONOTE_PUBLIC_ADDRESS_TEXTBLOB_VER          0
 #define CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW            18
-#define CURRENT_TRANSACTION_VERSION                     2
-#define CURRENT_BLOCK_MAJOR_VERSION                     1
-#define CURRENT_BLOCK_MINOR_VERSION                     0
 #define CRYPTONOTE_BLOCK_FUTURE_TIME_LIMIT              60*2
-
 #define CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE             10
 
 #define BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW               60
 #define BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW_V12           30
 
+#define CURRENT_TRANSACTION_VERSION                     2
+#define CURRENT_BLOCK_MAJOR_VERSION                     1
+#define CURRENT_BLOCK_MINOR_VERSION                     0
+
+#define ALLOW_DEBUG_COMMANDS
 // Total number coins to be generated
 #define MONEY_SUPPLY_ETN                                ((uint64_t)(2100000000000)) // ETN MONEY_SUPPLY
 #define MONEY_SUPPLY                                    ((uint64_t)(21000000000000)) // after the ETNX fork
@@ -59,30 +61,30 @@
 
 // Number of smallest units in one coin
 #define COIN                                            ((uint64_t)1000000000000) // 1 * pow(10, 12)
-
 #define EMISSION_SPEED_FACTOR_PER_MINUTE                (20)
 #define FINAL_SUBSIDY_PER_MINUTE                        ((uint64_t)1200000) // 0.000001200000 CRFI
+#define FINAL_SUBSIDY_PER_BLOCK                         ((uint64_t)120000) // 0.000000120000 CRFI
 
 #define CRYPTONOTE_REWARD_BLOCKS_WINDOW                 100
- 
+#define CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE       240 * 1024    // 240kB, used for emissions
 #define CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_V2    60000 //size of block (bytes) after which reward for block calculated using block size
 #define CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_V1    20000 //size of block (bytes) after which reward for block calculated using block size - before first fork
 #define CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_V5    300000 //size of block (bytes) after which reward for block calculated using block size - second change, from v5
 #define CRYPTONOTE_COINBASE_BLOB_RESERVED_SIZE          600
 #define CRYPTONOTE_DISPLAY_DECIMAL_POINT                12
-
 #define CRYPTONOTE_TX_FEE_RESERVED_SIZE                 3
 #define CRYPTONOTE_BLOCK_FEE_REWARD_ZONE_V5             21
 
 #define FEE_PER_KB_OLD                                  ((uint64_t)120000) // .1 * pow(10, 1)
 #define FEE_PER_KB_V2                                   ((uint64_t)120000) // .4 * pow(10, 1)
-#define FEE_PER_KB                                      ((uint64_t)120000) 
-#define FEE_PER_KB_V3                                   ((uint64_t)1200000) 
+#define FEE_PER_KB                                      ((uint64_t)120000) // 0.000000120000 
+#define FEE_PER_KB_V3                                   ((uint64_t)20000000) // 0.000020000000
 #define DYNAMIC_FEE_PER_KB_BASE_FEE                     ((uint64_t)2500000000) // .25 * pow(10, 8)
 #define DYNAMIC_FEE_PER_KB_BASE_BLOCK_REWARD            ((uint64_t)2500000000) // .25 * pow(10, 8)
-#define DYNAMIC_FEE_PER_KB_BASE_FEE_V5                  ((uint64_t)2500000000 * (uint64_t)CRYPTONOTE_TX_FEE_RESERVED_SIZE / CRYPTONOTE_BLOCK_FEE_REWARD_ZONE_V5)
+#define DYNAMIC_FEE_PER_KB_BASE_FEE_V5                  ((uint64_t)20000000 * (uint64_t)CRYPTONOTE_TX_FEE_RESERVED_SIZE / CRYPTONOTE_BLOCK_FEE_REWARD_ZONE_V5)
 
 #define ORPHANED_BLOCKS_MAX_COUNT                       100
+#define BLOCK_SIZE_GROWTH_FAVORED_ZONE                  ((uint64_t) (CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE * 4))
 
 #define DIFFICULTY_TARGET_V1                            60  // seconds - before first fork
 #define DIFFICULTY_WINDOW                               720 // blocks
@@ -91,38 +93,33 @@
 #define DIFFICULTY_CUT_V1                               60  // timestamps to cut after sorting
 #define DIFFICULTY_CUT_V2                               6   // timestamps to cut after sorting
 #define DIFFICULTY_BLOCKS_COUNT                         DIFFICULTY_WINDOW + DIFFICULTY_LAG
-
 #define DIFFICULTY_TARGET_V2                            120  // seconds
 #define DIFFICULTY_TARGET_V3                            6  // seconds
 #define DIFFICULTY_WINDOW_V2                            70
 #define DIFFICULTY_WINDOW_V3                            60
-
+#define DIFFICULTY_TARGET                               DIFFICULTY_TARGET_V2  // alias, used for emissions (should this be v3?)
+#define DIFFICULTY_BLOCKS_ESTIMATE_TIMESPAN             DIFFICULTY_TARGET_V1 // alias; used by tests
 #define DIFFICULTY_BLOCKS_COUNT_V2                      DIFFICULTY_WINDOW_V2
 #define DIFFICULTY_BLOCKS_COUNT_V3                      DIFFICULTY_WINDOW_V3
 #define DIFFICULTY_BLOCKS_COUNT_V12                     DIFFICULTY_WINDOW_V2
+
 #define CRYPTONOTE_BLOCK_FUTURE_TIME_LIMIT_V2           DIFFICULTY_TARGET_V1 * 2 // https://github.com/zawy12/difficulty-algorithms/issues/3
 #define CRYPTONOTE_BLOCK_FUTURE_TIME_LIMIT_V12          60*5
 #define CRYPTONOTE_BLOCK_FUTURE_TIME_LIMIT_CRYSTALEUM   6*7
-
 #define CRYPTONOTE_LOCKED_TX_ALLOWED_DELTA_SECONDS_V1   DIFFICULTY_TARGET_V1 * CRYPTONOTE_LOCKED_TX_ALLOWED_DELTA_BLOCKS
 #define CRYPTONOTE_LOCKED_TX_ALLOWED_DELTA_SECONDS_V2   DIFFICULTY_TARGET_V2 * CRYPTONOTE_LOCKED_TX_ALLOWED_DELTA_BLOCKS
 #define CRYPTONOTE_LOCKED_TX_ALLOWED_DELTA_BLOCKS       1
-
-#define DIFFICULTY_BLOCKS_ESTIMATE_TIMESPAN             DIFFICULTY_TARGET_V1 //just alias; used by tests
-
+#define CRYPTONOTE_MEMPOOL_TX_LIVETIME                  (86400*5) //seconds, five days
+#define CRYPTONOTE_MEMPOOL_TX_FROM_ALT_BLOCK_LIVETIME   604800    //seconds, one week
 
 #define BLOCKS_IDS_SYNCHRONIZING_DEFAULT_COUNT          10000  //by default, blocks ids count in synchronizing
 #define BLOCKS_SYNCHRONIZING_DEFAULT_COUNT_PRE_V4       100    //by default, blocks count in blocks downloading
 #define BLOCKS_SYNCHRONIZING_DEFAULT_COUNT              20     //by default, blocks count in blocks downloading
 
-#define CRYPTONOTE_MEMPOOL_TX_LIVETIME                  (86400*5) //seconds, five days
-#define CRYPTONOTE_MEMPOOL_TX_FROM_ALT_BLOCK_LIVETIME   604800    //seconds, one week
-
 #define COMMAND_RPC_GET_BLOCKS_FAST_MAX_COUNT           1000
 
 #define P2P_LOCAL_WHITE_PEERLIST_LIMIT                  5000
 #define P2P_LOCAL_GRAY_PEERLIST_LIMIT                   2500
-
 #define P2P_DEFAULT_CONNECTIONS_COUNT                   8
 #define P2P_DEFAULT_HANDSHAKE_INTERVAL                  60           //secondes
 #define P2P_DEFAULT_PACKET_MAX_SIZE                     50000000     //50000000 bytes maximum packet size
@@ -133,30 +130,14 @@
 #define P2P_DEFAULT_HANDSHAKE_INVOKE_TIMEOUT            5000       //5 seconds
 #define P2P_DEFAULT_WHITELIST_CONNECTIONS_PERCENT       70
 #define P2P_DEFAULT_ANCHOR_CONNECTIONS_COUNT            2
-
 #define P2P_FAILED_ADDR_FORGET_SECONDS                  (60*60)     //1 hour
 #define P2P_IP_BLOCKTIME                                (60*60*24)  //24 hour
 #define P2P_IP_FAILS_BEFORE_BLOCK                       10
 #define P2P_IDLE_CONNECTION_KILL_INTERVAL               (5*60) //5 minutes
-
 #define P2P_SUPPORT_FLAG_FLUFFY_BLOCKS                  0x01
 #define P2P_SUPPORT_FLAGS                               P2P_SUPPORT_FLAG_FLUFFY_BLOCKS
 
-#define ALLOW_DEBUG_COMMANDS
-
-#define CRYPTONOTE_NAME                                 "crystaleum"
-#define CRYPTONOTE_POOLDATA_FILENAME                    "poolstate.bin"
-#define CRYPTONOTE_BLOCKCHAINDATA_FILENAME              "data.mdb"
-#define CRYPTONOTE_BLOCKCHAINDATA_LOCK_FILENAME         "lock.mdb"
-#define P2P_NET_DATA_FILENAME                           "p2pstate.bin"
-#define MINER_CONFIG_FILE_NAME                          "miner_conf.json"
-
-#define THREAD_STACK_SIZE                               5 * 1024 * 1024
-
 // coin emission change interval/speed configs
-#define CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE       240 * 1024    // 240kB, used for emissions
-#define BLOCK_SIZE_GROWTH_FAVORED_ZONE                  ((uint64_t) (CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE * 4))
-#define DIFFICULTY_TARGET                               DIFFICULTY_TARGET_V2  // just alias, used for emissions
 #define COIN_EMISSION_MONTH_INTERVAL                    6  // months to change emission speed
 #define COIN_EMISSION_HEIGHT_INTERVAL                   ((uint64_t) (COIN_EMISSION_MONTH_INTERVAL * (30.4375 * 24 * 3600) / DIFFICULTY_TARGET)) // calculated to # of heights to change emission speed
 #define PEAK_COIN_EMISSION_YEAR                         4
@@ -167,26 +148,30 @@
 #define HF_VERSION_MIN_MIXIN_4                          7
 #define HF_VERSION_MIN_MIXIN_6                          8
 
-#define CRYPTONOTE_RINGDB_DIR                           ".crystaleum-shared-ringdb" // shared-ringdb"
-
 #define MIN_MIXIN                                       1      // minimum mixin allowed
-#define MAX_MIXIN                                       150    // maximum mixin allowed
+#define MAX_MIXIN                                       100    // maximum mixin allowed
 #define DEFAULT_MIXIN                                   6     // default mixin
+#define DEFAULT_TXPOOL_MAX_SIZE                         648000000ull // 3 days at 300000, in bytes
 #define PER_KB_FEE_QUANTIZATION_DECIMALS                8
 
+#define CRYPTONOTE_NAME                                 "crystaleum"
+#define CRYPTONOTE_POOLDATA_FILENAME                    "poolstate.bin"
+#define CRYPTONOTE_RINGDB_DIR                           ".crystaleum-ringdb" // shared-ringdb"
+#define CRYPTONOTE_BLOCKCHAINDATA_FILENAME              "data.mdb"
+#define CRYPTONOTE_BLOCKCHAINDATA_LOCK_FILENAME         "lock.mdb"
+#define P2P_NET_DATA_FILENAME                           "p2pstate.bin"
+#define MINER_CONFIG_FILE_NAME                          "miner_conf.json"
+#define THREAD_STACK_SIZE                               5 * 1024 * 1024
 #define HASH_OF_HASHES_STEP                             256
-
-#define DEFAULT_TXPOOL_MAX_SIZE                         648000000ull // 3 days at 300000, in bytes
 
 // New constants are intended to go here
 namespace config
 {
   uint64_t const DEFAULT_FEE_ATOMIC_XMR_PER_KB = 5;
   uint8_t const FEE_CALCULATION_MAX_RETRIES = 10;
-  uint64_t const DEFAULT_DUST_THRESHOLD = ((uint64_t)120000); // 
-  uint64_t const BASE_REWARD_CLAMP_THRESHOLD = ((uint64_t)1000000000000); // pow(10, 12)
+  uint64_t const DEFAULT_DUST_THRESHOLD = ((uint64_t)20000000); // 2 * pow(10, 7)
+  uint64_t const BASE_REWARD_CLAMP_THRESHOLD = ((uint64_t)100000000); // pow(10, 8)
   std::string const P2P_REMOTE_DEBUG_TRUSTED_PUB_KEY = "0000000000000000000000000000000000000000000000000000000000000000";
-
   uint64_t const CRYPTONOTE_PUBLIC_ADDRESS_BASE58_PREFIX = 343; //cx
   uint64_t const CRYPTONOTE_PUBLIC_INTEGRATED_ADDRESS_BASE58_PREFIX = 340; //cT
   uint64_t const CRYPTONOTE_PUBLIC_SUBADDRESS_BASE58_PREFIX = 439; //Xc
@@ -194,7 +179,7 @@ namespace config
   uint16_t const RPC_DEFAULT_PORT = 11025;
   uint16_t const ZMQ_RPC_DEFAULT_PORT = 11026;
   boost::uuids::uuid const NETWORK_ID = { {
-    0x22, 0x44, 0x66, 0xA8, 0xF8 , 0xF4, 0xF8,0xE4, 0xA8, 0xA4, 0xF8 , 0x42, 0xD8, 0x42,  0x68, 0xEA
+    0x30, 0x88, 0x66, 0xA8, 0xF8 , 0xF4, 0xF8,0xE4, 0xA8, 0xA4, 0xF6 , 0x90, 0xD8, 0x30,  0x91, 0xEA
     } }; // Bender's nightmare
   std::string const GENESIS_TX = "011201ff00011e026bc5c7db8a664f652d78adb587ac4d759c6757258b64ef9cba3c0354e64fb2e42101abca6a39c561d0897be183eb0143990eba201aa7d2c652ab0555d28bb4b70728";
   uint32_t const GENESIS_NONCE = 10000;

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -63,7 +63,7 @@
 #define COIN                                            ((uint64_t)1000000000000) // 1 * pow(10, 12)
 #define EMISSION_SPEED_FACTOR_PER_MINUTE                (20)
 #define FINAL_SUBSIDY_PER_MINUTE                        ((uint64_t)1200000) // 0.000001200000 CRFI
-#define FINAL_SUBSIDY_PER_BLOCK                         ((uint64_t)1392468) // 0.000001392468 CRFI
+#define FINAL_SUBSIDY_PER_BLOCK                         ((uint64_t)392468)  // 0.000000392468 CRFI
 
 #define CRYPTONOTE_REWARD_BLOCKS_WINDOW                 100
 #define CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE       240 * 1024    // 240kB, used for emissions

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -63,7 +63,7 @@
 #define COIN                                            ((uint64_t)1000000000000) // 1 * pow(10, 12)
 #define EMISSION_SPEED_FACTOR_PER_MINUTE                (20)
 #define FINAL_SUBSIDY_PER_MINUTE                        ((uint64_t)1200000) // 0.000001200000 CRFI
-#define FINAL_SUBSIDY_PER_BLOCK                         ((uint64_t)120000) // 0.000000120000 CRFI
+#define FINAL_SUBSIDY_PER_BLOCK                         ((uint64_t)592468)  // 0.000000592468 CRFI
 
 #define CRYPTONOTE_REWARD_BLOCKS_WINDOW                 100
 #define CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE       240 * 1024    // 240kB, used for emissions

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -78,7 +78,7 @@
 #define FEE_PER_KB_OLD                                  ((uint64_t)120000) // .1 * pow(10, 1)
 #define FEE_PER_KB_V2                                   ((uint64_t)120000) // .4 * pow(10, 1)
 #define FEE_PER_KB                                      ((uint64_t)120000) // 0.000000120000 
-#define FEE_PER_KB_V3                                   ((uint64_t)20000000) // 0.000020000000
+#define FEE_PER_KB_V3                                   ((uint64_t)1000000) //0.000001000000
 #define DYNAMIC_FEE_PER_KB_BASE_FEE                     ((uint64_t)2500000000) // .25 * pow(10, 8)
 #define DYNAMIC_FEE_PER_KB_BASE_BLOCK_REWARD            ((uint64_t)2500000000) // .25 * pow(10, 8)
 #define DYNAMIC_FEE_PER_KB_BASE_FEE_V5                  ((uint64_t)20000000 * (uint64_t)CRYPTONOTE_TX_FEE_RESERVED_SIZE / CRYPTONOTE_BLOCK_FEE_REWARD_ZONE_V5)
@@ -169,7 +169,7 @@ namespace config
 {
   uint64_t const DEFAULT_FEE_ATOMIC_XMR_PER_KB = 500;
   uint8_t const FEE_CALCULATION_MAX_RETRIES = 10;
-  uint64_t const DEFAULT_DUST_THRESHOLD = ((uint64_t)20000000); // 2 * pow(10, 7)
+  uint64_t const DEFAULT_DUST_THRESHOLD = ((uint64_t)1000000); // 2 * pow(10, 7)
   uint64_t const BASE_REWARD_CLAMP_THRESHOLD = ((uint64_t)100000000); // pow(10, 8)
   std::string const P2P_REMOTE_DEBUG_TRUSTED_PUB_KEY = "0000000000000000000000000000000000000000000000000000000000000000";
   uint64_t const CRYPTONOTE_PUBLIC_ADDRESS_BASE58_PREFIX = 343; //cx

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -73,7 +73,7 @@
 #define MAINNET_HARDFORK_V14_HEIGHT ((uint64_t)(337816)) // MAINNET v14 hard fork
 #define MAINNET_HARDFORK_V15_HEIGHT ((uint64_t)(337838)) // MAINNET v15 hard fork 
 #define MAINNET_HARDFORK_CRYSTALEUM_HEIGHT ((uint64_t)(500060)) // MAINNET crystaleum hard fork
-#define MAINNET_HARDFORK_V17_HEIGHT ((uint64_t)(1174966)) // MAINNET v17 hard fork 
+#define MAINNET_HARDFORK_V17_HEIGHT ((uint64_t)(1012915)) // MAINNET v17 hard fork 
 
 #define TESTNET_HARDFORK_V1_HEIGHT ((uint64_t)(1)) // TESTNET v1 
 #define TESTNET_HARDFORK_V7_HEIGHT ((uint64_t)(307003)) // TESTNET v7 hard fork 

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -73,6 +73,7 @@
 #define MAINNET_HARDFORK_V14_HEIGHT ((uint64_t)(337816)) // MAINNET v14 hard fork
 #define MAINNET_HARDFORK_V15_HEIGHT ((uint64_t)(337838)) // MAINNET v15 hard fork 
 #define MAINNET_HARDFORK_CRYSTALEUM_HEIGHT ((uint64_t)(500060)) // MAINNET crystaleum hard fork
+#define MAINNET_HARDFORK_V17_HEIGHT ((uint64_t)(1174966)) // MAINNET v17 hard fork 
 
 #define TESTNET_HARDFORK_V1_HEIGHT ((uint64_t)(1)) // TESTNET v1 
 #define TESTNET_HARDFORK_V7_HEIGHT ((uint64_t)(307003)) // TESTNET v7 hard fork 
@@ -137,8 +138,10 @@ static const struct {
   { 14, MAINNET_HARDFORK_V14_HEIGHT, 0, 1530884769 },
   // Version 15
   { 15, MAINNET_HARDFORK_V15_HEIGHT, 0, 1530885769 },  
-  // version 20 starts from block 307004, which is on or around the 18th of September, 2020. Fork time finalised on 2020-09-18.
-  { 16, MAINNET_HARDFORK_CRYSTALEUM_HEIGHT, 0, 1600402349 }
+  // version 16 starts from block 307004, which is on or around the 18th of September, 2020. Fork time finalised on 2020-09-18.
+  { 16, MAINNET_HARDFORK_CRYSTALEUM_HEIGHT, 0, 1600402349 },
+  // Version 17
+  { 17, MAINNET_HARDFORK_V17_HEIGHT, 0, 1614894341 }
 	
 };
 static const uint64_t mainnet_hard_fork_version_1_till = MAINNET_HARDFORK_V7_HEIGHT-1;
@@ -3208,9 +3211,14 @@ bool Blockchain::check_fee(size_t blob_size, uint64_t fee) const
   uint64_t block_height = m_db->height() - 1;
   uint64_t fee_per_kb;
   auto DYNAMIC_FEE_APPROVAL = 0;
-  if (DYNAMIC_FEE_APPROVAL != 100)
-  {
-    fee_per_kb = FEE_PER_KB;
+  if (DYNAMIC_FEE_APPROVAL != 100){
+	  if (version <= 16) {
+		  return FEE_PER_KB;
+	  }
+	  else { 
+		  return FEE_PER_KB_V3;
+	  }
+		  
   }
   else
   {
@@ -3242,8 +3250,15 @@ uint64_t Blockchain::get_dynamic_per_kb_fee_estimate(uint64_t grace_blocks) cons
   uint64_t block_height = m_db->height() - 1;
 	
    auto DYNAMIC_FEE_APPROVAL = 0;
-  if (DYNAMIC_FEE_APPROVAL != 100)
-    return FEE_PER_KB;
+  if (DYNAMIC_FEE_APPROVAL != 100){
+	  if (version <= 16) {
+		  return FEE_PER_KB;
+	  }
+	  else { 
+		  return FEE_PER_KB_V3;
+	  }
+		  
+  }
 
   if (grace_blocks >= CRYPTONOTE_REWARD_BLOCKS_WINDOW)
     grace_blocks = CRYPTONOTE_REWARD_BLOCKS_WINDOW - 1;

--- a/src/daemon/rpc_command_executor.cpp
+++ b/src/daemon/rpc_command_executor.cpp
@@ -999,7 +999,7 @@ bool t_rpc_command_executor::print_transaction_pool_stats() {
   else
   {
     uint64_t backlog = (res.pool_stats.bytes_total + full_reward_zone - 1) / full_reward_zone;
-    backlog_message = (boost::format("estimated %u block (%u minutes) backlog") % backlog % (backlog * DIFFICULTY_TARGET_V2 / 60)).str();
+    backlog_message = (boost::format("estimated %u block (%u minutes) backlog") % backlog % (backlog * DIFFICULTY_TARGET_V3 / 6)).str();
   }
 
   tools::msg_writer() << n_transactions << " tx(es), " << res.pool_stats.bytes_total << " bytes total (min " << res.pool_stats.bytes_min << ", max " << res.pool_stats.bytes_max << ", avg " << avg_bytes << ", median " << res.pool_stats.bytes_med << ")" << std::endl

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -788,7 +788,7 @@ bool simple_wallet::print_fee_info(const std::vector<std::string> &args/* = std:
       std::string msg;
       if (priority == m_wallet->get_default_priority() || (m_wallet->get_default_priority() == 0 && priority == 2))
         msg = tr(" (current)");
-      uint64_t minutes_low = nblocks_low * DIFFICULTY_TARGET_V2 / 60, minutes_high = nblocks_high * DIFFICULTY_TARGET_V2 / 60;
+      uint64_t minutes_low = nblocks_low * DIFFICULTY_TARGET_V3 / 6, minutes_high = nblocks_high * DIFFICULTY_TARGET_V3 / 6;
       if (nblocks_high == nblocks_low)
         message_writer() << (boost::format(tr("%u block (%u minutes) backlog at priority %u%s")) % nblocks_low % minutes_low % priority % msg).str();
       else

--- a/src/simplewallet/simplewallet.h
+++ b/src/simplewallet/simplewallet.h
@@ -275,7 +275,7 @@ namespace cryptonote
       void update(uint64_t height, bool force = false)
       {
         auto current_time = std::chrono::system_clock::now();
-        const auto node_update_threshold = std::chrono::seconds(DIFFICULTY_TARGET_V1 / 2); // use min of V1/V2
+        const auto node_update_threshold = std::chrono::seconds(DIFFICULTY_TARGET_V3 / 2); // use min of V1/V2
         if (node_update_threshold < current_time - m_blockchain_height_update_time || m_blockchain_height <= height)
         {
           update_blockchain_height();

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -3130,7 +3130,7 @@ crypto::secret_key wallet2::generate(const std::string& wallet_, const epee::wip
  {
    // -1 month for fluctuations in block time and machine date/time setup.
    // avg seconds per block
-   const int seconds_per_block = DIFFICULTY_TARGET_V1;
+   const int seconds_per_block = DIFFICULTY_TARGET_V3;
    // ~num blocks per month
    const uint64_t blocks_per_month = 60*60*24*30/seconds_per_block;
 
@@ -9189,11 +9189,11 @@ uint64_t wallet2::get_daemon_blockchain_target_height(string &err)
 uint64_t wallet2::get_approximate_blockchain_height() const
 {
   // time of v2 fork
-  const time_t fork_time = m_nettype == TESTNET ? 1526030997 : m_nettype == STAGENET ? (time_t)-1/*TODO*/ : 1527643352;
+  const time_t fork_time = m_nettype == TESTNET ? 1526030997 : m_nettype == STAGENET ? (time_t)-1/*TODO*/ : 1600402349;
   // v2 fork block
   const uint64_t fork_block = m_nettype == TESTNET ? 57 : m_nettype == STAGENET ? (uint64_t)-1/*TODO*/ : 307000;
   // avg seconds per block
-  const int seconds_per_block = DIFFICULTY_TARGET_V2;
+  const int seconds_per_block = DIFFICULTY_TARGET_V3;
   // Calculated blockchain height
   uint64_t approx_blockchain_height = fork_block + (time(NULL) - fork_time)/seconds_per_block;
   // testnet got some huge rollbacks, so the estimation is way off

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -5339,16 +5339,27 @@ uint64_t wallet2::get_dynamic_per_kb_fee_estimate() const
   if (!result)
     return fee;
   LOG_PRINT_L1("Failed to query per kB fee, using " << print_money(FEE_PER_KB));
-  return FEE_PER_KB;
+          if (use_fork_rules(17, 10)) {
+		  return FEE_PER_KB_V3;
+	  }
+	  else {
+		  return FEE_PER_KB;
+	  }
 }
 //----------------------------------------------------------------------------------------------------
 uint64_t wallet2::get_per_kb_fee() const
 {
   if(m_light_wallet)
     return m_light_wallet_per_kb_fee;
-  bool use_dyn_fee = use_fork_rules(HF_VERSION_DYNAMIC_FEE, -720 * 1);
-  if (!use_dyn_fee)
-    return FEE_PER_KB;
+  bool use_dyn_fee = use_fork_rules(HF_VERSION_DYNAMIC_FEE, 10);
+  if (!use_dyn_fee){
+	  if (use_fork_rules(17, 10)) {
+		  return FEE_PER_KB_V3;
+	  }
+	  else {
+		  return FEE_PER_KB;
+	  }
+  }
 
   return get_dynamic_per_kb_fee_estimate();
 }

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -54,6 +54,7 @@ using namespace epee;
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "wallet.rpc"
+#define DEFAULT_AUTO_REFRESH_PERIOD 20 // seconds
 
 namespace
 {
@@ -103,13 +104,18 @@ namespace tools
   {
     m_stop = false;
     m_net_server.add_idle_handler([this](){
+      if (m_auto_refresh_period == 0) // disabled
+        return true;
+      if (boost::posix_time::microsec_clock::universal_time() < m_last_auto_refresh_time + boost::posix_time::seconds(m_auto_refresh_period))
+        return true;
       try {
         if (m_wallet) m_wallet->refresh();
       } catch (const std::exception& ex) {
         LOG_ERROR("Exception at while refreshing, what=" << ex.what());
       }
+      m_last_auto_refresh_time = boost::posix_time::microsec_clock::universal_time();
       return true;
-    }, 20000);
+    }, 1000);
     m_net_server.add_idle_handler([this](){
       if (m_stop.load(std::memory_order_relaxed))
       {
@@ -228,6 +234,9 @@ namespace tools
       }
       assert(bool(http_login));
     } // end auth enabled
+
+    m_auto_refresh_period = DEFAULT_AUTO_REFRESH_PERIOD;
+    m_last_auto_refresh_time = boost::posix_time::min_date_time;
 
     m_net_server.set_threads_prefix("RPC");
     auto rng = [](size_t len, uint8_t *ptr) { return crypto::rand(len, ptr); };
@@ -2227,6 +2236,28 @@ namespace tools
     {
       er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
       er.message = "Failed to delete address book entry";
+      return false;
+    }
+    return true;
+  }
+  //------------------------------------------------------------------------------------------------------------------------------
+  bool wallet_rpc_server::on_auto_refresh(const wallet_rpc::COMMAND_RPC_AUTO_REFRESH::request& req, wallet_rpc::COMMAND_RPC_AUTO_REFRESH::response& res, epee::json_rpc::error& er, const connection_context *ctx)
+  {
+    if (m_restricted)
+    {
+      er.code = WALLET_RPC_ERROR_CODE_DENIED;
+      er.message = "Command unavailable in restricted mode.";
+      return false;
+    }
+    try
+    {
+      m_auto_refresh_period = req.enable ? req.period ? req.period : DEFAULT_AUTO_REFRESH_PERIOD : 0;
+      MINFO("Auto refresh now " << (m_auto_refresh_period ? std::to_string(m_auto_refresh_period) + " seconds" : std::string("disabled")));
+      return true;
+    }
+    catch (const std::exception& e)
+    {
+      handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR);
       return false;
     }
     return true;

--- a/src/wallet/wallet_rpc_server.h
+++ b/src/wallet/wallet_rpc_server.h
@@ -121,6 +121,7 @@ namespace tools
         MAP_JON_RPC_WE("get_address_book",   on_get_address_book,   wallet_rpc::COMMAND_RPC_GET_ADDRESS_BOOK_ENTRY)
         MAP_JON_RPC_WE("add_address_book",   on_add_address_book,   wallet_rpc::COMMAND_RPC_ADD_ADDRESS_BOOK_ENTRY)
         MAP_JON_RPC_WE("delete_address_book",on_delete_address_book,wallet_rpc::COMMAND_RPC_DELETE_ADDRESS_BOOK_ENTRY)
+        MAP_JON_RPC_WE("auto_refresh", on_auto_refresh, wallet_rpc::COMMAND_RPC_AUTO_REFRESH)
         MAP_JON_RPC_WE("rescan_spent",       on_rescan_spent,       wallet_rpc::COMMAND_RPC_RESCAN_SPENT)
         MAP_JON_RPC_WE("start_mining",       on_start_mining,       wallet_rpc::COMMAND_RPC_START_MINING)
         MAP_JON_RPC_WE("stop_mining",        on_stop_mining,        wallet_rpc::COMMAND_RPC_STOP_MINING)
@@ -189,6 +190,7 @@ namespace tools
       bool on_get_address_book(const wallet_rpc::COMMAND_RPC_GET_ADDRESS_BOOK_ENTRY::request& req, wallet_rpc::COMMAND_RPC_GET_ADDRESS_BOOK_ENTRY::response& res, epee::json_rpc::error& er);
       bool on_add_address_book(const wallet_rpc::COMMAND_RPC_ADD_ADDRESS_BOOK_ENTRY::request& req, wallet_rpc::COMMAND_RPC_ADD_ADDRESS_BOOK_ENTRY::response& res, epee::json_rpc::error& er);
       bool on_delete_address_book(const wallet_rpc::COMMAND_RPC_DELETE_ADDRESS_BOOK_ENTRY::request& req, wallet_rpc::COMMAND_RPC_DELETE_ADDRESS_BOOK_ENTRY::response& res, epee::json_rpc::error& er);
+      bool on_auto_refresh(const wallet_rpc::COMMAND_RPC_AUTO_REFRESH::request& req, wallet_rpc::COMMAND_RPC_AUTO_REFRESH::response& res, epee::json_rpc::error& er, const connection_context *ctx = NULL);
       bool on_rescan_spent(const wallet_rpc::COMMAND_RPC_RESCAN_SPENT::request& req, wallet_rpc::COMMAND_RPC_RESCAN_SPENT::response& res, epee::json_rpc::error& er);
       bool on_start_mining(const wallet_rpc::COMMAND_RPC_START_MINING::request& req, wallet_rpc::COMMAND_RPC_START_MINING::response& res, epee::json_rpc::error& er);
       bool on_stop_mining(const wallet_rpc::COMMAND_RPC_STOP_MINING::request& req, wallet_rpc::COMMAND_RPC_STOP_MINING::response& res, epee::json_rpc::error& er);

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -1578,6 +1578,29 @@ namespace wallet_rpc
       END_KV_SERIALIZE_MAP()
     };
   };
+  
+  struct COMMAND_RPC_AUTO_REFRESH
+  {
+    struct request_t
+    {
+      bool enable;
+      uint32_t period; // seconds
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_OPT(enable, true)
+        KV_SERIALIZE_OPT(period, (uint32_t)0)
+      END_KV_SERIALIZE_MAP()
+    };
+    typedef epee::misc_utils::struct_init<request_t> request;
+
+    struct response_t
+    {
+      BEGIN_KV_SERIALIZE_MAP()
+      END_KV_SERIALIZE_MAP()
+    };
+    typedef epee::misc_utils::struct_init<response_t> response;
+  };
+
 
   struct COMMAND_RPC_START_MINING
   {


### PR DESCRIPTION
In this Critical (mandatory) update; 
-Network fee increase, as a tax on future transactions. All network fees are 100% granted to the mining community when each block gets mined the network fees are added to the block reward.
-Checkpoint to increase sync speed
-Adjust arbitrary logging to suit difficulty target
-Fork block will help with popping blocks to the proper chain. May need to use crystaleum-blockchain-import tool with flag --pop 100 to ensure the proper organization of your local node sync state.

We are returning to block 1012915 in recovery effort for those who suffered from recent attacks at Altilly.com exchange. This will clearly be the best effort we can to resume normal operations. Block 1012915 was before the attacks at Altilly exchange. All coins will return to their original locations before entering the exchange, For example CrystalID. http://oracle.crystaleum.org/tx/48cfcd8af7808046a33b4e4f7b65911145e6b7f65dd5219c4b4b9639b6175329